### PR TITLE
Environment variable for production

### DIFF
--- a/src/main/resources/application-ci.properties
+++ b/src/main/resources/application-ci.properties
@@ -1,7 +1,7 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/zhelperdb
+spring.datasource.url=${ZHELPER_DB_URL}
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=postgres
-spring.datasource.password=454db517J
+spring.datasource.username=${ZHELPER_DB_USERNAME}
+spring.datasource.password=${ZHELPER_DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 


### PR DESCRIPTION
Хранить секретные данные подключения к бд и прочие переменные конфигурации приложения в репозитории плохая идея. Плюс лишает возможности маневров при разворачивании приложения на нескольких серверах. Переменные, указанные в конфиге, перенес на сервер.